### PR TITLE
Fix NullPointerException in convertIssue()

### DIFF
--- a/jira.core/src/me/glindholm/connector/eclipse/internal/jira/core/service/rest/JiraRestConverter.java
+++ b/jira.core/src/me/glindholm/connector/eclipse/internal/jira/core/service/rest/JiraRestConverter.java
@@ -314,7 +314,9 @@ public class JiraRestConverter {
             issue.setLabels(rawIssue.getLabels().toArray(new String[rawIssue.getLabels().size()]));
         }
 
-        issue.setVotes(rawIssue.getVotes().getVotes());
+        if(rawIssue.getVotes() != null) {
+            issue.setVotes(rawIssue.getVotes().getVotes());
+        }
 
         BasicWatchers watched = rawIssue.getWatched();
         issue.setWatched(watched.isWatching());


### PR DESCRIPTION
Our Jira instance (Jira v8.20.7) throw the following Exception: 

!ENTRY org.eclipse.mylyn.tasks.core 4 0 2022-07-20 10:15:56.143
!MESSAGE Synchronization failed
!STACK 0
java.lang.NullPointerException
	at me.glindholm.connector.eclipse.internal.jira.core.service.rest.JiraRestConverter.convertIssue(JiraRestConverter.java:317)
	at me.glindholm.connector.eclipse.internal.jira.core.service.rest.JiraRestClientAdapter$4.call(JiraRestClientAdapter.java:315)
	at me.glindholm.connector.eclipse.internal.jira.core.service.rest.JiraRestClientAdapter$4.call(JiraRestClientAdapter.java:1)
	at me.glindholm.connector.eclipse.internal.jira.core.service.rest.JiraRestClientAdapter.call(JiraRestClientAdapter.java:765)
	at me.glindholm.connector.eclipse.internal.jira.core.service.rest.JiraRestClientAdapter.getIssues(JiraRestClientAdapter.java:300)
	at me.glindholm.connector.eclipse.internal.jira.core.service.JiraClient.findIssues(JiraClient.java:358)
	at me.glindholm.connector.eclipse.internal.jira.core.service.JiraClient.findIssues(JiraClient.java:351)
	at me.glindholm.connector.eclipse.internal.jira.core.service.JiraClient.search(JiraClient.java:731)
	at me.glindholm.connector.eclipse.internal.jira.core.JiraRepositoryConnector.performQuery(JiraRepositoryConnector.java:144)
	at org.eclipse.mylyn.internal.tasks.core.sync.SynchronizeQueriesJob.synchronizeQuery(SynchronizeQueriesJob.java:306)
	at org.eclipse.mylyn.internal.tasks.core.sync.SynchronizeQueriesJob.synchronizeQueries(SynchronizeQueriesJob.java:263)
	at org.eclipse.mylyn.internal.tasks.core.sync.SynchronizeQueriesJob.run(SynchronizeQueriesJob.java:194)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)